### PR TITLE
Python: Add support for arbitrary sequences of hashable objects

### DIFF
--- a/bindings/python/edlib.pyx
+++ b/bindings/python/edlib.pyx
@@ -40,8 +40,10 @@ def map_to_bytes(query, target, additional_equalities):
         query_bytes = ''.join(input_mapping[c] for c in query).encode('ascii')
         target_bytes = ''.join(input_mapping[c] for c in target).encode('ascii')
         if additional_equalities is not None:
-            additional_equalities = [(input_mapping[a], input_mapping[b])
-                                     for a, b in additional_equalities]
+            additional_equalities = [
+                (input_mapping[a], input_mapping[b])
+                for a, b in additional_equalities
+                if a in input_mapping and b in input_mapping]
     return query_bytes, target_bytes, additional_equalities
 
 


### PR DESCRIPTION
This implements @Martinsos' suggestion from https://github.com/Martinsos/edlib/issues/79 to add support for sequences of arbitrary hashable objects in the Python bindings. If either query or target contain non-ascii values, they are mapped into an ASCII alphabet and the resulting byte sequences are used for doing the alignment.

One limitation that we can't get around at the moment is that the query and target sequence together must not contain more than 256 unique values.

It certainly is not the ideal way to go about this, but it should serve as an acceptable workaround for a lot of use cases until https://github.com/Martinsos/edlib/issues/90 is implemented.

This should help with #123, #114, #109, #104, #89 and #79.