### PR TITLE
feature to have python output actual alignment

### DIFF
--- a/bindings/python/README.rst
+++ b/bindings/python/README.rst
@@ -36,11 +36,17 @@ Installation
 API
 ---
 
-Edlib has only one function:
+Edlib has two functions, `align()` and `getNiceAlignment()`:
 
 .. code:: python
 
     align(query, target, [mode], [task], [k])
+
+.. code:: python
+
+    getNiceAlignment(alignResutl, query, target)
+
+
 
 To learn more about it, type :code:`help(edlib.align)` in your python interpreter.
 
@@ -62,6 +68,15 @@ Usage
     print(result["alphabetLength"])  # 5
     print(result["locations"])  # [(1, 4)]
     print(result["cigar"])  # "4="
+
+    result = edlib.align("elephant", "telephone", task="path")  ## users must use 'task="path"' 
+    niceAlign = edlib.getNiceAlignment(result, "elephant", "telephone")
+    print(niceAlign['query_aligned'])  # "-elephant"
+    print(niceAlign['matched_aligned'])  # "-|||||.|."
+    print(niceAlign['target_aligned'])  # "telephone"
+
+
+
 
 ---------
 Benchmark

--- a/bindings/python/test.py
+++ b/bindings/python/test.py
@@ -15,6 +15,47 @@ result = edlib.align("ACTG", "CACTRT", mode="HW", task="path", additionalEqualit
 if not (result and result["editDistance"] == 0):
     testFailed = True
 
+
+resultNW = edlib.align(query="TAAGGATGGTCCCATTC", target="AAGGGGTCTCATATC", mode="NW", task="path")
+test_getNiceNW = edlib.getNiceAlignment(resultNW, query="TAAGGATGGTCCCATTC", target="AAGGGGTCTCATATC")
+if not (len(test_getNiceNW['query_aligned']) == 18 and len(test_getNiceNW['target_aligned'])==18):
+    testFailed = True
+if not (test_getNiceNW['query_aligned'] == 'TAAGGATGGTCCCAT-TC'):
+	testFailed = True
+if not (test_getNiceNW['matched_aligned'] == '-||||--||||.|||-||'):
+	testFailed = True
+if not (test_getNiceNW['target_aligned'] == '-AAGG--GGTCTCATATC'):
+	testFailed = True
+
+
+resultHW = edlib.align(query="TAAGGATGGTCCCATTC", target="AAGGGGTCTCATATC", mode="HW", task="path")
+test_getNiceHW = edlib.getNiceAlignment(resultHW, query="TAAGGATGGTCCCATTC", target="AAGGGGTCTCATATC")
+if not (len(test_getNiceHW['query_aligned']) == 18 and len(test_getNiceHW['target_aligned'])==18):
+    testFailed = True
+if not (test_getNiceHW['query_aligned'] == 'TAAGGATGGTCCCAT-TC'):
+	testFailed = True
+if not (test_getNiceHW['matched_aligned'] == '-||||--||||.|||-||'):
+	testFailed = True
+if not (test_getNiceHW['target_aligned'] == '-AAGG--GGTCTCATATC'):
+	testFailed = True
+
+
+resultSHW = edlib.align(query="TAAGGATGGTCCCATTC", target="AAGGGGTCTCATATC", mode="SHW", task="path")
+test_getNiceSHW = edlib.getNiceAlignment(resultSHW, query="TAAGGATGGTCCCATTC", target="AAGGGGTCTCATATC")
+if not (len(test_getNiceSHW['query_aligned']) == 18 and len(test_getNiceSHW['target_aligned'])==18):
+    testFailed = True
+if not (test_getNiceSHW['query_aligned'] == 'TAAGGATGGTCCCAT-TC'):
+	testFailed = True
+if not (test_getNiceSHW['matched_aligned'] == '-||||--||||.|||-||'):
+	testFailed = True
+if not (test_getNiceSHW['target_aligned'] == '-AAGG--GGTCTCATATC'):
+	testFailed = True
+
+result_taskDistance = edlib.align(query="TAAGGATGGTCCCATTC", target="AAGGGGTCTCATATC", mode="NW", task="distance")
+if not (result_taskDistance["cigar"] == None):
+    testFailed = True
+
+
 if testFailed:
     print("Some of the tests failed!")
 else:


### PR DESCRIPTION
This is a (flawed) start, related to the following issue: https://github.com/Martinsos/edlib/issues/127 (and this duplicate: https://github.com/Martinsos/edlib/issues/129)

This uses @yech1990 's example to parse the extended cigar (which is just a compressed version of "alignment" from cpp edlib) from the Cython script `edlib.pyx`

> : A method cigarToNiceAlignment that would take cigar returned by align + whatever else it needs (query and target, maybe mode I am not sure at the moment, check cpp implementation of NICE) and returns string which is NICE alignment. That should be it! And it should mostly be code you already wrote here, just slightly modified

I didn't quite do this, but just revised the `align()` method. 

The problem:

As far as I can tell, `ccigar` is always empty. 

I've tried in the Cython code printing these variables:

```
string_alignmentLength = <bytes> cresult.alignmentLength
```

It appears that `cresult.alignmentLength` is also empty. `cedlib.EDLIB_CIGAR_EXTENDED` is some sort of integer? 

These are the issues I'm running into trying to finish this PR


