### PR TITLE
Fix `-Wold-style-cast`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,15 +25,15 @@ install:
 
 before_script:
   # Build C/C++ library and apps.
-  - mkdir -p build && cd build && cmake .. && make && cd ..
+  - mkdir -p build && cd build && CXXFLAGS="-Werror" cmake -DCMAKE_VERBOSE_MAKEFILE=ON .. && make && cd ..
 
   # Build Python source distribution and install Edlib from it.
   - if [ $TRAVIS_OS_NAME == "linux" ]; then cd bindings/python && make sdist && cd ../..; fi
   - if [ $TRAVIS_OS_NAME == "linux" ]; then sudo -H pip install bindings/python/dist/edlib*.tar.gz; fi
 
 script:
-  # Test C/C++ library.
-  - build/bin/runTests
+  # Test C/C++ library using CTest.
+  - cd build && make test && cat Testing/Temporary/LastTest.log && cd ..
   # Check for memory leaks. Returns 2 if there was a memory leak/error, otherwise returns runTests exit code,
   # which is 0 if all went fine or 1 if some of the tests failed. I test for memory leaks only on linux because
   # osx returns errors from system libraries, which I would have to supress.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,9 @@ if(CMAKE_BUILD_TYPE MATCHES Debug)
   message("Debug mode")
 endif()
 
+include(GNUInstallDirs)
+include(CheckCXXCompilerFlag)
+
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)  # Falling back to different standard it not allowed.
 set(CMAKE_CXX_EXTENSIONS NO)  # Make sure no compiler-specific features are used.
@@ -21,6 +24,15 @@ if(MSVC)
   endif()
 else()
   message("Setting warning flags")
+
+  check_cxx_compiler_flag(-Wold-style-cast WOLD_STYLE_CAST)
+  if (WOLD_STYLE_CAST)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wold-style-cast")
+  endif()
+  check_cxx_compiler_flag(-Wshadow WSHADOW)
+  if (WSHADOW)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wshadow")
+  endif()
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -pedantic")
 endif()
 
@@ -48,8 +60,13 @@ target_include_directories(edlib_static PUBLIC
 add_executable(helloWorld apps/hello-world/helloWorld.c)
 target_link_libraries(helloWorld edlib_static)
 
-add_executable(runTests test/runTests.cpp)
-target_link_libraries(runTests edlib_static)
+include(CTest)
+if (BUILD_TESTING)
+  add_executable(runTests test/runTests.cpp)
+  target_link_libraries(runTests edlib_static)
+
+  add_test(edlib_tests ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/runTests)
+endif()
 
 if (NOT WIN32) # If on windows, do not build binaries that do not support windows.
   add_executable(edlib-aligner apps/aligner/aligner.cpp)
@@ -58,5 +75,5 @@ endif()
 
 
 # Create target 'install' for installing libraries.
-install(TARGETS edlib edlib_static DESTINATION lib)
-install(FILES edlib/include/edlib.h DESTINATION include)
+install(TARGETS edlib edlib_static DESTINATION ${CMAKE_INSTALL_LIBDIR})
+install(FILES edlib/include/edlib.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ edlibAlign("hello", 5, "world!", 6, edlibDefaultAlignConfig()).editDistance;
 ```
 
 ## Features
-* Calculates **edit distance (Levehnstein distance)**.
+* Calculates **edit distance (Levenshtein distance)**.
 * It can find **optimal alignment path** (instructions how to transform first sequence into the second sequence).
 * It can find just the **start and/or end locations of alignment path** - can be useful when speed is more important than having exact alignment path.
 * Supports **multiple [alignment methods](#alignment-methods)**: global(**NW**), prefix(**SHW**) and infix(**HW**), each of them useful for different scenarios.

--- a/apps/aligner/aligner.cpp
+++ b/apps/aligner/aligner.cpp
@@ -20,7 +20,7 @@ void printAlignment(const char* query, const char* target,
 
 // For debugging
 void printSeq(const vector<char> &seq) {
-    for (int i = 0; i < (int) seq.size(); i++)
+    for (int i = 0; i < static_cast<int>(seq.size()); i++)
         printf("%d ", seq[i]);
     printf("\n");
 }
@@ -183,10 +183,10 @@ int main(int argc, char * const argv[]) {
         if (numBestSeqs > 0) {
             if (scores[i] >= 0) {
                 bestScores.push(scores[i]);
-                if ((int) bestScores.size() > numBestSeqs) {
+                if (static_cast<int>(bestScores.size()) > numBestSeqs) {
                     bestScores.pop();
                 }
-                if ((int) bestScores.size() == numBestSeqs) {
+                if (static_cast<int>(bestScores.size()) == numBestSeqs) {
                     k = bestScores.top() - 1;
                     if (kArg >= 0 && kArg < k)
                         k = kArg;
@@ -229,7 +229,7 @@ int main(int argc, char * const argv[]) {
         printf("\n");
 
         if (bestScores.size() > 0) {
-            printf("%d best scores:\n", (int)bestScores.size());
+            printf("%d best scores:\n", static_cast<int>(bestScores.size()));
             scoreLimit = bestScores.top();
         } else {
             printf("Scores:\n");
@@ -260,7 +260,7 @@ int main(int argc, char * const argv[]) {
     }
 
     clock_t finish = clock();
-    double cpuTime = ((double)(finish-start))/CLOCKS_PER_SEC;
+    double cpuTime = static_cast<double>(finish-start)/CLOCKS_PER_SEC;
     printf("\nCpu time of searching: %lf\n", cpuTime);
     // ---------------------------------------------------------------------------- //
 

--- a/edlib/src/edlib.cpp
+++ b/edlib/src/edlib.cpp
@@ -49,7 +49,7 @@ struct Block {
     int score; // score of last cell in block;
 
     Block() {}
-    Block(Word P, Word M, int score) :P(P), M(M), score(score) {}
+    Block(Word p, Word m, int s) :P(p), M(m), score(s) {}
 };
 
 

--- a/test/SimpleEditDistance.h
+++ b/test/SimpleEditDistance.h
@@ -56,13 +56,13 @@ int calcEditDistanceSimple(const char* query, int queryLength,
             printf("\n");*/
 
         if (mode != EDLIB_MODE_NW || c == targetLength - 1) { // For NW check only last column
-            int score = newC[queryLength - 1];
-            if (bestScore == -1 || score <= bestScore) {
-                if (score < bestScore) {
+            int newScore = newC[queryLength - 1];
+            if (bestScore == -1 || newScore <= bestScore) {
+                if (newScore < bestScore) {
                     positions.clear();
                     numPositions = 0;
                 }
-                bestScore = score;
+                bestScore = newScore;
                 positions.push_back(c);
                 numPositions++;
             }

--- a/test/SimpleEditDistance.h
+++ b/test/SimpleEditDistance.h
@@ -79,7 +79,7 @@ int calcEditDistanceSimple(const char* query, int queryLength,
     *score = bestScore;
     if (positions.size() > 0) {
         *positions_ = new int[positions.size()];
-        *numPositions_ = (int) positions.size();
+        *numPositions_ = static_cast<int>(positions.size());
         copy(positions.begin(), positions.end(), *positions_);
     } else {
         *positions_ = NULL;

--- a/test/runTests.cpp
+++ b/test/runTests.cpp
@@ -35,7 +35,7 @@ int main(int argc, char* argv[]) {
     // per each algorithm. Default is 100.
     int numRandomTests = 100;
     if (argc > 1) {
-        numRandomTests = (int) strtol(argv[1], NULL, 10);
+        numRandomTests = static_cast<int>(strtol(argv[1], NULL, 10));
     }
 
     srand(42);
@@ -79,7 +79,7 @@ int main(int argc, char* argv[]) {
 
 void fillRandomly(char* seq, int seqLength, int alphabetLength) {
     for (int i = 0; i < seqLength; i++)
-        seq[i] = (char) rand() % alphabetLength;
+        seq[i] = static_cast<char>(rand()) % alphabetLength;
 }
 
 // Returns true if all tests passed, false otherwise.
@@ -94,8 +94,8 @@ bool runRandomTests(int numTests, EdlibAlignMode mode, bool findAlignment) {
         bool failed = false;
         int queryLength = 50 + rand() % 300;
         int targetLength = 500 + rand() % 10000;
-        char* query = (char *) malloc(sizeof(char) * queryLength);
-        char* target = (char *) malloc(sizeof(char) * targetLength);
+        char* query = static_cast<char *>(malloc(sizeof(char) * queryLength));
+        char* target = static_cast<char *>(malloc(sizeof(char) * targetLength));
         fillRandomly(query, queryLength, alphabetLength);
         fillRandomly(target, targetLength, alphabetLength);
 
@@ -204,8 +204,8 @@ bool runRandomTests(int numTests, EdlibAlignMode mode, bool findAlignment) {
     printf("%d/%d", numTests - numTestsFailed, numTests);
     printf("\x1B[0m");
     printf(" random tests passed!\n");
-    double mTime = ((double)(timeEdlib))/CLOCKS_PER_SEC;
-    double sTime = ((double)(timeSimple))/CLOCKS_PER_SEC;
+    double mTime = static_cast<double>(timeEdlib)/CLOCKS_PER_SEC;
+    double sTime = static_cast<double>(timeSimple)/CLOCKS_PER_SEC;
     printf("Time Edlib: %lf\n", mTime);
     printf("Time Simple: %lf\n", sTime);
     printf("Times faster: %.2lf\n", sTime / mTime);
@@ -432,8 +432,8 @@ bool test12() {
     const char* query = "GCATATCAATAAGCGGAGGA";
     const char* target = "TAACAAGGTTTCCGTAGGTGAACCTGCGGAAGGATCATTATCGAATAAACTTGATGGGTTGTCGCTGGCTTCTAGGAGCATGTGCACATCCGTCATTTTTATCCATCCACCTGTGCACCTTTTGTAGTCTTTGGAGGTAATAAGCGTGAATCTATCGAGGTCCTCTGGTCCTCGGAAAGAGGTGTTTGCCATATGGCTCGCCTTTGATACTCGCGAGTTACTCTAAGACTATGTCCTTTCATATACTACGAATGTAATAGAATGTATTCATTGGGCCTCAGTGCCTATAAAACATATACAACTTTCAGCAACGGATCTCTTGGCTCTCGCATCGATGAAGAACGCAGCGAAATGCGATAAGTAATGTGAATTGCAGAATTCAGTGAATCATCGAATCTTTGAACGCACCTTGCGCTCCTTGGTATTCCGAGGAGCATGCCTGTTTGAGTGTCATTAAATTCTCAACCCCTTCCGGTTTTTTGACTGGCTTTGGGGCTTGGATGTGGGGGATTCATTTGCGGGCCTCTGTAGAGGTCGGCTCCCCTGAAATGCATTAGTGGAACCGTTTGCGGTTACCGTCGCTGGTGTGATAACTATCTATGCCAAAGACAAACTGCTCTCTGATAGTTCTGCTTCTAACCGTCCATTTATTGGACAACATTATTATGAACACTTGACCTCAAATCAGGTAGGACTACCCGCTGAACTTAAGCATATCAATAAGCGGAGGAAAAGAAACTAACAAGGATTCCCCTAGTAACTGCGAGTGAAGCGGGAAAAGCTCAAATTTAAAATCTGGCGGTCTTTGGCCGTCCGAGTTGTAATCTAGAGAAGCGACACCCGCGCTGGACCGTGTACAAGTCTCCTGGAATGGAGCGTCATAGAGGGTGAGAATCCCGTCTCTGACACGGACTACCAGGGCTTTGTGGTGCGCTCTCAAAGAGTCGAGTTGTTTGGGAATGCAGCTCTAAATGGGTGGTAAATTCCATCTAAAGCTAAATATTGGCGAGAGACCGATAGCGAACAAGTACCGTGAGGGAAAGATGAAAAGAACTTTGGAAAGAGAGTTAAACAGTACGTGAAATTGCTGAAAGGGAAACGCTTGAAGTCAGTCGCGTTGGCCGGGGATCAGCCTCGCTTTTGCGTGGTGTATTTCCTGGTTGACGGGTCAGCATCAATTTTGACCGCTGGAAAAGGACTTGGGGAATGTGGCATCTTCGGATGTGTTATAGCCCTTTGTCGCATACGGCGGTTGGGATTGAGGAACTCAGCACGCCGCAAGGCCGGGTTTCGACCACGTTCGTGCTTAGGATGCTGGCATAATGGCTTTAATCGACCCGTCTTGAAACACGGACCAAGGAGTCTAACATGCCTGCGAGTGTTTGGGTGGAAAACCCGAGCGCGTAATGAAAGTGAAAGTTGAGATCCCTGTCGTGGGGAGCATCGACGCCCGGACCAGAACTTTTGGGACGGATCTGCGGTAGAGCATGTATGTTGGGACCCGAAAGATGGTGAACTATGCCTGAATAGGGTGAAGCCAGAGGAAACTCTGGTGGAGGCTCGTAGCGATTCTGACGTGCAAATCGATCGTCAAATTTGGGTATAGGGGCGAAAGACTAATCGAACCATCTAGTAGCTGGTTCCTGCCGAAGTTTCCCTCAGGATAGCAGAAACTCATATCAGATTTATGTGGTAAAGCGAATGATTAGAGGCCTTGGGGTTGAAACAACCTTAACCTATTCTCAAACTTTAAATATGTAAGAACGAGCCGTTTCTTGATTGAACCGCTCGGCGATTGAGAGTTTCTAGTGGGCCATTTTTGGTAAGCAGAACTGGCGATGCGGGATGAACCGAACGCGAGGTTAAGGTGCCGGAATTCACGCTCATCAGACACCACAAAAGGTGTTAGTTCATCTAGACAGCAGGACGGTGGCCATGGAAGTCGGAATCCGCTAAGGAGTGTGTAACAACTCACCTGCCGAATGAACTAGCCCTGAAAATGGATGGCGCTTAAGCGTGATACCCATACCTCGCCGTCAGCGTTGAAGTGACGCGCTGACGAGTAGGCAGGCGTGGAGGTCAGTGAAGAAGCCTTGGCAGTGATGCTGGGTGAAACGGCCTCC";
 
-    EdlibAlignResult result = edlibAlign(query, (int) std::strlen(query),
-                                         target, (int) std::strlen(target),
+    EdlibAlignResult result = edlibAlign(query, static_cast<int>(std::strlen(query)),
+                                         target, static_cast<int>(std::strlen(target)),
                                          edlibNewAlignConfig(-1, EDLIB_MODE_HW,EDLIB_TASK_LOC, additionalEqualities, 24));
     bool pass = result.status == EDLIB_STATUS_OK && result.editDistance == 0;
     printf(pass ? "\x1B[32m""OK""\x1B[0m\n" : "\x1B[31m""FAIL""\x1B[0m\n");
@@ -449,8 +449,8 @@ bool test13() {
     const char* query = "AA";
     const char* target = "B";
 
-    EdlibAlignResult result = edlibAlign(query, (int) std::strlen(query),
-                                         target, (int) std::strlen(target),
+    EdlibAlignResult result = edlibAlign(query, static_cast<int>(std::strlen(query)),
+                                         target, static_cast<int>(std::strlen(target)),
                                          edlibNewAlignConfig(-1, EDLIB_MODE_HW, EDLIB_TASK_PATH, NULL, 0));
     bool pass = result.status == EDLIB_STATUS_OK && result.editDistance == 2;
     printf(pass ? "\x1B[32m""OK""\x1B[0m\n" : "\x1B[31m""FAIL""\x1B[0m\n");
@@ -466,8 +466,8 @@ bool test14() {
     const char* query = "AA";
     const char* target = "B";
 
-    EdlibAlignResult result = edlibAlign(query, (int) std::strlen(query),
-                                         target, (int) std::strlen(target),
+    EdlibAlignResult result = edlibAlign(query, static_cast<int>(std::strlen(query)),
+                                         target, static_cast<int>(std::strlen(target)),
                                          edlibNewAlignConfig(-1, EDLIB_MODE_SHW, EDLIB_TASK_PATH, NULL, 0));
     bool pass = result.status == EDLIB_STATUS_OK && result.editDistance == 2;
     printf(pass ? "\x1B[32m""OK""\x1B[0m\n" : "\x1B[31m""FAIL""\x1B[0m\n");
@@ -480,8 +480,8 @@ bool test15() {
     const char* query = "AAABBB";
     const char* target = "BBBC";
 
-    EdlibAlignResult result = edlibAlign(query, (int) std::strlen(query),
-                                         target, (int) std::strlen(target),
+    EdlibAlignResult result = edlibAlign(query, static_cast<int>(std::strlen(query)),
+                                         target, static_cast<int>(std::strlen(target)),
                                          edlibNewAlignConfig(-1, EDLIB_MODE_HW, EDLIB_TASK_LOC, NULL, 0));
     bool pass = result.status == EDLIB_STATUS_OK && result.editDistance == 3;
     printf(pass ? "\x1B[32m""OK""\x1B[0m\n" : "\x1B[31m""FAIL""\x1B[0m\n");
@@ -494,8 +494,8 @@ bool test16() {
     const char* query = "BBBAAA";
     const char* target = "CBBB";
 
-    EdlibAlignResult result = edlibAlign(query, (int) std::strlen(query),
-                                         target, (int) std::strlen(target),
+    EdlibAlignResult result = edlibAlign(query, static_cast<int>(std::strlen(query)),
+                                         target, static_cast<int>(std::strlen(target)),
                                          edlibNewAlignConfig(-1, EDLIB_MODE_HW, EDLIB_TASK_LOC, NULL, 0));
     bool pass = result.status == EDLIB_STATUS_OK && result.editDistance == 3;
     printf(pass ? "\x1B[32m""OK""\x1B[0m\n" : "\x1B[31m""FAIL""\x1B[0m\n");

--- a/test/runTests.cpp
+++ b/test/runTests.cpp
@@ -151,11 +151,11 @@ bool runRandomTests(int numTests, EdlibAlignMode mode, bool findAlignment) {
             printf("Number of endLocations returned is not equal! Expected %d, got %d\n",
                    numLocations2, result.numLocations);
         } else {
-            for (int i = 0; i < result.numLocations; i++) {
-                if (result.endLocations[i] != endLocations2[i]) {
+            for (int j = 0; j < result.numLocations; j++) {
+                if (result.endLocations[j] != endLocations2[j]) {
                     failed = true;
                     printf("EndLocations at %d are not equal! Expected %d, got %d\n",
-                           i, endLocations2[i], result.endLocations[i]);
+                           j, endLocations2[j], result.endLocations[j]);
                     break;
                 }
             }


### PR DESCRIPTION
Hi @Martinsos,
Thanks for a great library! In our build systems, we always add `-Wold-style-cast`, in order to avoid C-style casts in C++. This PR is about using C++'s `static_cast` consistently in edlib. `static_cast` has a number of advantages and is recommended by the [C++ Core Guidelines](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#es49-if-you-must-use-a-cast-use-a-named-cast)

- It makes `grep`ing for casts easier
- It prevents certain dangerous casts that would trigger undefined behavior:

```
void fun1(char* x)
{
    int* i = (int*) x;
    int* j = static_cast<int*>(x);
}
```

the C-style cast succeeds, whereas the `static_cast` would cause the compiler to error out, for good reason (undefined behavior, likely violates strict aliasing and alignment requirements).