### PR TITLE
Modifying tests and aligner-app

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,13 +80,12 @@ add_library(staticTestLib STATIC test/testMultiDefinition/staticTestLib.cpp)
 add_executable(testMultiDefinition test/testMultiDefinition/testMultiDefinition.cpp)
 target_link_libraries(testMultiDefinition staticTestLib)
 
-#
-#if (NOT WIN32) # If on windows, do not build binaries that do not support windows.
-#  add_executable(edlib-aligner apps/aligner/aligner.cpp)
-#  target_link_libraries(edlib-aligner edlib)
-#endif()
-#
-#
+
+if (NOT WIN32) # If on windows, do not build binaries that do not support windows.
+  add_executable(edlib-aligner apps/aligner/aligner.cpp)
+  #target_link_libraries(edlib-aligner edlib)
+endif()
+
 ## Create target 'install' for installing libraries.
 #install(TARGETS edlib DESTINATION ${CMAKE_INSTALL_LIBDIR})
 #install(FILES edlib/include/edlib.hpp DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})

--- a/apps/aligner/aligner.cpp
+++ b/apps/aligner/aligner.cpp
@@ -11,6 +11,7 @@
 #include "edlib.hpp"
 
 using namespace std;
+using namespace edlib;
 
 int readFastaSequences(const char* path, vector< vector<char> >* seqs);
 

--- a/test/SimpleEditDistance.h
+++ b/test/SimpleEditDistance.h
@@ -15,8 +15,9 @@ int min3(int x, int y, int z) {
     return min(x, min(y, z));
 }
 
-int calcEditDistanceSimple(const char* query, int queryLength,
-                           const char* target, int targetLength,
+template <class Element=char>
+int calcEditDistanceSimple(const Element* query, int queryLength,
+                           const Element* target, int targetLength,
                            const edlib::EdlibAlignMode mode, int* score,
                            int** positions_, int* numPositions_) {
     int bestScore = -1;


### PR DESCRIPTION
This pull request contains two main changes;
1. Making aligner app back to work. Currently, it only supports character sequences.
2. Modify the previous tests to generate random sequences with any desired Element type and check their correctness and execution time. To achieve this aim, three template parameters are added to the previous random test functions, so now we can set the Element, AlphabetIdx, and also the alphabet size for random tests.
A new test is added for checking the AlphabetTooBigException. It has to be thrown when the alphabet size of input sequences is larger than the maximum value that can be stored in  AlphabetIdx.

