### PR TITLE
Enabling additional equalities for generic sequences (using sets) 

### DIFF
--- a/apps/aligner/aligner.cpp
+++ b/apps/aligner/aligner.cpp
@@ -168,7 +168,7 @@ int main(int argc, char * const argv[]) {
         EdlibAlignResult result;
         for (int rep = 0; rep < numRepeats; rep++) {  // Redundant repetition, for performance measurements.
             result = edlibAlign(query, queryLength, target, targetLength,
-                                edlibNewAlignConfig(k, modeCode, alignTask, NULL, 0));
+                                edlibNewAlignConfig<char>(k, modeCode, alignTask, NULL, 0));
             if (rep < numRepeats - 1) edlibFreeAlignResult(result);
         }
 

--- a/edlib/include/edlib.hpp
+++ b/edlib/include/edlib.hpp
@@ -78,15 +78,17 @@ namespace edlib {
 /**
  * @brief Defines two given characters as equal.
  */
-typedef struct {
-    char first;
-    char second;
-} EdlibEqualityPair;
+template <class Element=char>
+struct EdlibEqualityPair{
+    Element first;
+    Element second;
+};
 
 /**
  * @brief Configuration object for edlibAlign() function.
  */
-typedef struct {
+template <class Element=char>
+struct EdlibAlignConfig{
     /**
      * Set k to non-negative value to tell edlib that edit distance is not larger than k.
      * Smaller k can significantly improve speed of computation.
@@ -119,28 +121,30 @@ typedef struct {
      * or e.g. if you want edlib to be case insensitive.
      * Can be set to NULL if there are none.
      */
-    EdlibEqualityPair *additionalEqualities;
+    const EdlibEqualityPair<Element>* additionalEqualities;
 
     /**
      * Number of additional equalities, which is non-negative number.
      * 0 if there are none.
      */
     int additionalEqualitiesLength;
-} EdlibAlignConfig;
+};
 
 /**
  * Helper method for easy construction of configuration object.
  * @return Configuration object filled with given parameters.
  */
-inline EdlibAlignConfig edlibNewAlignConfig(int k, EdlibAlignMode mode, EdlibAlignTask task,
-                                            EdlibEqualityPair* additionalEqualities,
+template <class Element=char>
+EdlibAlignConfig<Element> edlibNewAlignConfig(int k, EdlibAlignMode mode, EdlibAlignTask task,
+                                            const EdlibEqualityPair<Element>* additionalEqualities,
                                             int additionalEqualitiesLength);
 
 /**
  * @return Default configuration object, with following defaults:
  *         k = -1, mode = EDLIB_MODE_NW, task = EDLIB_TASK_DISTANCE, no additional equalities.
  */
-inline EdlibAlignConfig edlibDefaultAlignConfig(void);
+template <class Element=char>
+EdlibAlignConfig<Element> edlibDefaultAlignConfig(void);
 
 
 /**
@@ -225,7 +229,7 @@ inline void edlibFreeAlignResult(EdlibAlignResult result);
 template<class Element=char, class AlphabetIdx=uint8_t>
 EdlibAlignResult edlibAlign(const Element* query, int queryLength,
                             const Element* target, int targetLength,
-                            const EdlibAlignConfig config);
+                            const EdlibAlignConfig<Element> config);
 
 
 /**

--- a/edlib/include/pairHash.hpp
+++ b/edlib/include/pairHash.hpp
@@ -1,0 +1,32 @@
+#include <functional>
+// This header file provides a hashing function for std::pair of any custom types.
+// Since there is no specialization of std::hash for std::pair<T1,T2> provided
+// in the standard library, we can use the implementation in this header file.
+
+
+/**
+ * Takes a seed and a value of any type. A Seed can be a hash code of other
+ * values or simply 0. It will generate a new hash code using the given seed and value.
+ * It can be called repeatedly to incrementally create a hash value from several variables.
+ * This "magical" implementation is adopted from Boost C++ Libraries.
+ * https://www.boost.org/doc/libs/1_35_0/doc/html/boost/hash_combine_id241013.html
+ * @param [in] seed The hash code of previous variables
+ * @param [in] v The value to be hashed using the given seed
+ */
+template <class T>
+inline void hash_combine(std::size_t & seed, const T & v)
+{
+    std::hash<T> hasher;
+    seed ^= hasher(v) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
+}
+
+template<typename S, typename T> struct pair_hash
+{
+    inline std::size_t operator()(const std::pair<S, T> & v) const
+    {
+        std::size_t seed = 0;
+        hash_combine(seed, v.first);
+        hash_combine(seed, v.second);
+        return seed;
+    }
+};

--- a/test/runTests.cpp
+++ b/test/runTests.cpp
@@ -142,7 +142,7 @@ bool runRandomTests(int numTests, EdlibAlignMode mode,
         start = clock();
         EdlibAlignResult result = edlibAlign<Element, AlphabetIdx>(
                 query, queryLength, target, targetLength,
-                edlibNewAlignConfig(-1, mode, findAlignment ? EDLIB_TASK_PATH : EDLIB_TASK_DISTANCE, NULL, 0));
+                edlibNewAlignConfig<Element>(-1, mode, findAlignment ? EDLIB_TASK_PATH : EDLIB_TASK_DISTANCE, NULL, 0));
         timeEdlib += clock() - start;
         if (result.alignment) {
             if (!checkAlignment<Element>(query, queryLength, target,
@@ -196,7 +196,7 @@ bool runRandomTests(int numTests, EdlibAlignMode mode,
             int scoreExpected = score2 > k ? -1 : score2;
             EdlibAlignResult result3 = edlibAlign<Element, AlphabetIdx>(
                     query, queryLength, target, targetLength,
-                    edlibNewAlignConfig(k, mode, findAlignment ? EDLIB_TASK_PATH : EDLIB_TASK_DISTANCE, NULL, 0));
+                    edlibNewAlignConfig<Element>(k, mode, findAlignment ? EDLIB_TASK_PATH : EDLIB_TASK_DISTANCE, NULL, 0));
             if (result3.editDistance != scoreExpected) {
                 failed = true;
                 printf("For k = %d score was %d but it should have been %d\n",
@@ -253,7 +253,7 @@ bool executeTest(const char* query, int queryLength,
                            mode, &scoreSimple, &endLocationsSimple, &numLocationsSimple);
 
     EdlibAlignResult result = edlibAlign(query, queryLength, target, targetLength,
-                                         edlibNewAlignConfig(-1, mode, EDLIB_TASK_PATH, NULL, 0));
+                                         edlibNewAlignConfig<char>(-1, mode, EDLIB_TASK_PATH, NULL, 0));
 
     if (result.editDistance != scoreSimple) {
         pass = false;
@@ -453,7 +453,7 @@ bool test11() {
 }
 
 bool test12() {
-    EdlibEqualityPair additionalEqualities[24] = {{'R','A'},{'R','G'},{'M','A'},{'M','C'},{'W','A'},{'W','T'},
+    EdlibEqualityPair<char> additionalEqualities[24] = {{'R','A'},{'R','G'},{'M','A'},{'M','C'},{'W','A'},{'W','T'},
                                                   {'S','C'},{'S','G'},{'Y','C'},{'Y','T'},{'K','G'},{'K','T'},
                                                   {'V','A'},{'V','C'},{'V','G'},{'H','A'},{'H','C'},{'H','T'},
                                                   {'D','A'},{'D','G'},{'D','T'},{'B','C'},{'B','G'},{'B','T'}};
@@ -462,7 +462,7 @@ bool test12() {
 
     EdlibAlignResult result = edlibAlign(query, static_cast<int>(std::strlen(query)),
                                          target, static_cast<int>(std::strlen(target)),
-                                         edlibNewAlignConfig(-1, EDLIB_MODE_HW,EDLIB_TASK_LOC, additionalEqualities, 24));
+                                         edlibNewAlignConfig<char>(-1, EDLIB_MODE_HW,EDLIB_TASK_LOC, additionalEqualities, 24));
     bool pass = result.status == EDLIB_STATUS_OK && result.editDistance == 0;
     printf(pass ? "\x1B[32m""OK""\x1B[0m\n" : "\x1B[31m""FAIL""\x1B[0m\n");
     edlibFreeAlignResult(result);
@@ -479,7 +479,7 @@ bool test13() {
 
     EdlibAlignResult result = edlibAlign(query, static_cast<int>(std::strlen(query)),
                                          target, static_cast<int>(std::strlen(target)),
-                                         edlibNewAlignConfig(-1, EDLIB_MODE_HW, EDLIB_TASK_PATH, NULL, 0));
+                                         edlibNewAlignConfig<char>(-1, EDLIB_MODE_HW, EDLIB_TASK_PATH, NULL, 0));
     bool pass = result.status == EDLIB_STATUS_OK && result.editDistance == 2;
     printf(pass ? "\x1B[32m""OK""\x1B[0m\n" : "\x1B[31m""FAIL""\x1B[0m\n");
     edlibFreeAlignResult(result);
@@ -496,7 +496,7 @@ bool test14() {
 
     EdlibAlignResult result = edlibAlign(query, static_cast<int>(std::strlen(query)),
                                          target, static_cast<int>(std::strlen(target)),
-                                         edlibNewAlignConfig(-1, EDLIB_MODE_SHW, EDLIB_TASK_PATH, NULL, 0));
+                                         edlibNewAlignConfig<char>(-1, EDLIB_MODE_SHW, EDLIB_TASK_PATH, NULL, 0));
     bool pass = result.status == EDLIB_STATUS_OK && result.editDistance == 2;
     printf(pass ? "\x1B[32m""OK""\x1B[0m\n" : "\x1B[31m""FAIL""\x1B[0m\n");
     edlibFreeAlignResult(result);
@@ -510,7 +510,7 @@ bool test15() {
 
     EdlibAlignResult result = edlibAlign(query, static_cast<int>(std::strlen(query)),
                                          target, static_cast<int>(std::strlen(target)),
-                                         edlibNewAlignConfig(-1, EDLIB_MODE_HW, EDLIB_TASK_LOC, NULL, 0));
+                                         edlibNewAlignConfig<char>(-1, EDLIB_MODE_HW, EDLIB_TASK_LOC, NULL, 0));
     bool pass = result.status == EDLIB_STATUS_OK && result.editDistance == 3;
     printf(pass ? "\x1B[32m""OK""\x1B[0m\n" : "\x1B[31m""FAIL""\x1B[0m\n");
     edlibFreeAlignResult(result);
@@ -524,7 +524,7 @@ bool test16() {
 
     EdlibAlignResult result = edlibAlign(query, static_cast<int>(std::strlen(query)),
                                          target, static_cast<int>(std::strlen(target)),
-                                         edlibNewAlignConfig(-1, EDLIB_MODE_HW, EDLIB_TASK_LOC, NULL, 0));
+                                         edlibNewAlignConfig<char>(-1, EDLIB_MODE_HW, EDLIB_TASK_LOC, NULL, 0));
     bool pass = result.status == EDLIB_STATUS_OK && result.editDistance == 3;
     printf(pass ? "\x1B[32m""OK""\x1B[0m\n" : "\x1B[31m""FAIL""\x1B[0m\n");
     edlibFreeAlignResult(result);
@@ -561,7 +561,7 @@ bool testCigar() {
 }
 
 bool testCustomEqualityRelation() {
-    EdlibEqualityPair additionalEqualities[6] = {{'R','A'},{'R','G'},{'N','A'},{'N','C'},{'N','T'},{'N','G'}};
+    EdlibEqualityPair<char> additionalEqualities[6] = {{'R','A'},{'R','G'},{'N','A'},{'N','C'},{'N','T'},{'N','G'}};
 
     bool allPass = true;
 
@@ -570,7 +570,7 @@ bool testCustomEqualityRelation() {
 
     printf("Degenerate nucleotides (HW): ");
     EdlibAlignResult result = edlibAlign(query, 19, target, 41,
-                                         edlibNewAlignConfig(-1, EDLIB_MODE_HW, EDLIB_TASK_PATH,
+                                         edlibNewAlignConfig<char>(-1, EDLIB_MODE_HW, EDLIB_TASK_PATH,
                                                              additionalEqualities, 6));
     bool pass = result.status == EDLIB_STATUS_OK && result.editDistance == 1;
     edlibFreeAlignResult(result);


### PR DESCRIPTION
This PR contains the implementation of an unordered_set of pairs and using it to activate additional equalities for generic sequences.

Here is the list of main changes:
1. Added pairhash.hpp which contains a hash function for std::pair
2. If we are given an array of additional equality pairs, an unordered_set of these pairs is created. For example if we are given these pairs; (a,b) , (b,c), (a,d)  -> we make this set { (a,b), (b,a), (b,c), (c,b), (a,d), (d,a) } which contains both permutations for each pair.
3. This unordered_set is used for checking the equality of any two elements. To speed up the process, searching the set is avoided as much as possible. We check the below conditions in advance, if any of them is true we ignore searching the set;
- 1. If two given elements are the same
- 2. If at least one of the given elements is not a member of any additional equality pair (using a prepossessed boolean array)

It can speed up the process because we expect that a large portion of comparisons fall into at least one of the above scenarios.
