### PR TITLE
update cmake installation to support VCPKG port

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,7 @@
 cmake_minimum_required(VERSION 3.2 FATAL_ERROR)
-project(edlib VERSION 1.2.5)
+project(edlib VERSION 1.2.6)
+
+option(EDLIB_ENABLE_INSTALL "Generate the install target" ON)
 
 set(MACOSX (${CMAKE_SYSTEM_NAME} MATCHES "Darwin"))
 
@@ -74,14 +76,42 @@ if (NOT WIN32) # If on windows, do not build binaries that do not support window
   target_link_libraries(edlib-aligner edlib)
 endif()
 
-
-# Create target 'install' for installing libraries.
-install(TARGETS edlib DESTINATION ${CMAKE_INSTALL_LIBDIR})
-install(FILES edlib/include/edlib.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
-
 # configure and install pkg-config file
 configure_file(
     ${CMAKE_CURRENT_SOURCE_DIR}/edlib.pc.in
     ${CMAKE_CURRENT_BINARY_DIR}/edlib-1.pc
     @ONLY)
-install(FILES ${CMAKE_CURRENT_BINARY_DIR}/edlib-1.pc DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
+
+if(EDLIB_ENABLE_INSTALL)
+	install(FILES ${CMAKE_CURRENT_BINARY_DIR}/edlib-1.pc DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
+	include(CMakePackageConfigHelpers)
+	set(EDLIB_CMAKE_DIR "${CMAKE_INSTALL_LIBDIR}/cmake/edlib" CACHE STRING
+	  "Installation directory for cmake files, relative to ${CMAKE_INSTALL_PREFIX}.")
+	set(version_config "${PROJECT_BINARY_DIR}/edlib-config-version.cmake")
+	set(project_config "${PROJECT_BINARY_DIR}/edlib-config.cmake")
+	set(targets_export_name edlib-targets)
+
+	# Generate the version, config and target files into the build directory.
+	write_basic_package_version_file(
+		${version_config}
+		VERSION ${VERSION}
+		COMPATIBILITY AnyNewerVersion)
+	configure_package_config_file(
+		${PROJECT_SOURCE_DIR}/edlib-config.cmake.in
+		${project_config}
+		INSTALL_DESTINATION ${EDLIB_CMAKE_DIR})
+	export(TARGETS edlib NAMESPACE edlib::
+		FILE ${PROJECT_BINARY_DIR}/${targets_export_name}.cmake)
+
+	# Install version, config and target files.
+	# These are cmake config files and they are useful for some consumers, for example vcpkg.
+	install(
+		FILES ${project_config} ${version_config}
+		DESTINATION ${EDLIB_CMAKE_DIR})
+	install(EXPORT ${targets_export_name} DESTINATION ${EDLIB_CMAKE_DIR}
+		NAMESPACE edlib::)
+	
+	# Create target 'install' for installing libraries.
+	install(TARGETS edlib EXPORT ${targets_export_name} DESTINATION ${CMAKE_INSTALL_LIBDIR})
+	install(FILES edlib/include/edlib.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+endif()

--- a/edlib-config.cmake.in
+++ b/edlib-config.cmake.in
@@ -1,0 +1,4 @@
+@PACKAGE_INIT@
+
+include(${CMAKE_CURRENT_LIST_DIR}/@targets_export_name@.cmake)
+check_required_components(edlib)


### PR DESCRIPTION
Hello, I am porting this library to VCPKG but I had to make some changes to the build process. (Here is the [link](https://github.com/microsoft/vcpkg/pull/12490) to the VCPKG PR)

For context, with this patch I can install edlib through vcpkg simply by doing
`vcpkg install edlib`

and then I add these 2 lines in my project's CMakeList:
`find_package(edlib CONFIG REQUIRED)`
`target_link_libraries(main PRIVATE edlib::edlib)`

and voila! I can use your library in my project :)

Thanks