### PR TITLE
Add more const

### DIFF
--- a/edlib/include/edlib.h
+++ b/edlib/include/edlib.h
@@ -115,7 +115,7 @@ extern "C" {
          * or e.g. if you want edlib to be case insensitive.
          * Can be set to NULL if there are none.
          */
-        EdlibEqualityPair* additionalEqualities;
+        const EdlibEqualityPair* additionalEqualities;
 
         /**
          * Number of additional equalities, which is non-negative number.
@@ -129,7 +129,7 @@ extern "C" {
      * @return Configuration object filled with given parameters.
      */
     EdlibAlignConfig edlibNewAlignConfig(int k, EdlibAlignMode mode, EdlibAlignTask task,
-                                         EdlibEqualityPair* additionalEqualities,
+                                         const EdlibEqualityPair* additionalEqualities,
                                          int additionalEqualitiesLength);
 
     /**

--- a/edlib/src/edlib.cpp
+++ b/edlib/src/edlib.cpp
@@ -1460,7 +1460,7 @@ static string transformSequences(const char* const queryOriginal, const int quer
 
 
 extern "C" EdlibAlignConfig edlibNewAlignConfig(int k, EdlibAlignMode mode, EdlibAlignTask task,
-                                                EdlibEqualityPair* additionalEqualities,
+                                                const EdlibEqualityPair* additionalEqualities,
                                                 int additionalEqualitiesLength) {
     EdlibAlignConfig config;
     config.k = k;


### PR DESCRIPTION
Hi @Martinsos 
a small PR to add some useful `const` qualifers. Without these `const` qualifiers, the following pattern isn't possible:

```
// we want to use edlib in case-insensitive mode
constexpr std::array<EdlibEqualityPair, 5> EdlibCaseInsensitiveArray{{
    {'A', 'a'}, {'C', 'c'}, {'G', 'g'}, {'T', 't'}, {'N', 'n'},
}};

const EdlibAlignConfig edlibConfig{
    -1,
    EDLIB_MODE_NW,
    EDLIB_TASK_PATH,
    EdlibCaseInsensitiveArray.data(),
    EdlibCaseInsensitiveArray.size(),
};

void foo() {
  [...]
  const auto alnResult =
                edlibAlign(query.c_str(), query.size(), target.c_str(), target.size(), edlibConfig);
  [...]
}
```
because the `std::array` would return a `const`-qualified `EdlibEqualityPair*`. With this pattern, all parameters get burned into read-only memory on compilation, which improves cache lookup and makes code safer.