### PR TITLE
Python Wheels

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,78 @@
 language: cpp
 dist: trusty
 
-# In order to catch as many weird edge cases in the code with -Werror as
-# possible, we want to test a large range of old and new compilers on both
-# Linux and macOS. This gives us the best possible coverage while maintaining
-# compatibility with a large number of compilers.
-matrix:
+stages:
+    - ccpp
+    - python
+
+env:
+    global:
+        # Uploading wheels to PyPI, TWINE_PASSWORD is set to a PyPI API token in Travis settings
+        - TWINE_USERNAME=__token__
+
+.ccpp: &ccpp
+    stage: ccpp
+    
+    before_install:
+      - eval "${MATRIX_EVAL}"
+    
+    install:
+      - if [ $TRAVIS_OS_NAME == "linux" ]; then sudo apt-get install valgrind; fi
+    
+    before_script:
+      # Build C/C++ library and apps.
+      - mkdir -p build && cd build && CXXFLAGS="-Werror" cmake -GNinja .. && ninja -v && cd ..
+    
+    script:
+      # Test C/C++ library using CTest.
+      - ninja -C build -v test && cat build/Testing/Temporary/LastTest.log
+      # Check for memory leaks. Returns 2 if there was a memory leak/error, otherwise returns runTests exit code,
+      # which is 0 if all went fine or 1 if some of the tests failed. I test for memory leaks only on linux because
+      # osx returns errors from system libraries, which I would have to supress.
+      # This is run only on smaller number of tests, since executing on valgrind is slow.
+      - if [ $TRAVIS_OS_NAME == "linux" ]; then valgrind --quiet --error-exitcode=2 --tool=memcheck --leak-check=full build/bin/runTests 2; fi
+
+.python: &python
+    stage: python
+
+    install:
+        - wget -qO- https://bootstrap.pypa.io/get-pip.py | python3
+        - python3 -m pip install cibuildwheel==1.6.1
+
+    script:
+        # build the wheels, put them into './wheelhouse'
+        # cibuildwheel needs to be run from python directory. The python
+        # directory is mounted in the docker build containers, so we need
+        # to copy the edlib source before running cibuild wheel
+        - cd bindings/python && make edlib
+        - |
+            CIBW_SKIP="cp27-* pp* *-manylinux_i686" \
+            CIBW_BEFORE_BUILD="make sdist" \
+            CIBW_TEST_COMMAND="python3 {project}/test.py" \
+            python3 -m cibuildwheel --output-dir wheelhouse
+        # TODO: mv sdist build (and upload) to distinct target
+        - if [ $TRAVIS_OS_NAME == "linux" ]; then make sdist; fi
+
+    after_success:
+        # if the release was tagged, upload them to PyPI
+        - cd bindings/python
+        - |
+            if [[ $TRAVIS_TAG ]]; then
+                python3 -m pip install twine
+                python3 -m twine upload wheelhouse/*.whl
+                if [ $TRAVIS_OS_NAME == "linux" ]; then python3 -m twine upload dist/edlib-*.tar.gz; fi
+            else
+                echo "Skipping twine upload because not a tag, files built:"
+                ls -l wheelhouse
+                ls -l dist
+            fi
+
+jobs:
   include:
+    # In order to catch as many weird edge cases in the code with -Werror as
+    # possible, we want to test a large range of old and new compilers on both
+    # Linux and macOS. This gives us the best possible coverage while maintaining
+    # compatibility with a large number of compilers.
     - name: "GCC 4.9 (Linux)"
       os: linux
       addons:
@@ -18,6 +84,7 @@ matrix:
             - ninja-build
       env:
          - MATRIX_EVAL="export CC=gcc-4.9 && export CXX=g++-4.9"
+      <<: *ccpp
 
     - name: "GCC 9 (Linux)"
       os: linux
@@ -30,6 +97,7 @@ matrix:
             - ninja-build
       env:
         - MATRIX_EVAL="export CC=gcc-9 && export CXX=g++-9"
+      <<: *ccpp
 
     - name: "Clang 5.0 (Linux)"
       os: linux
@@ -42,6 +110,7 @@ matrix:
             - ninja-build
       env:
         - MATRIX_EVAL="export CC=clang-5.0 && export CXX=clang++-5.0"
+      <<: *ccpp
 
     - name: "Clang Xcode 11 (Mac)"
       os: osx
@@ -50,35 +119,21 @@ matrix:
         homebrew:
           packages:
             - ninja
+      <<: *ccpp
 
-# NOTE: Currently I commented out testing of python binding on OSX because they do not support
-# Python building and I have to provide the tools myself. I could probably install correct pip
-# (and maybe python) version myself (homebrew?), however I haven't gotten to that yet.
+    #
+    # Building python wheels
+    #
+    - name: "linux wheel"
+      language: python
+      python:
+          - "3.6"
+      services: docker
+      <<: *python
 
-before_install:
-  - eval "${MATRIX_EVAL}"
+    - name: "macos wheel"
+      os: osx
+      language: shell
+      <<: *python
 
-install:
-  - if [ $TRAVIS_OS_NAME == "linux" ]; then sudo apt-get install valgrind; fi
-  - if [ $TRAVIS_OS_NAME == "linux" ]; then sudo -H pip install cython; fi  # Needed to build Python module.
-  - if [ $TRAVIS_OS_NAME == "linux" ]; then sudo -H pip install cogapp; fi  # Needed to build Python module.
-
-before_script:
-  # Build C/C++ library and apps.
-  - mkdir -p build && cd build && CXXFLAGS="-Werror" cmake -GNinja .. && ninja -v && cd ..
-
-  # Build Python source distribution and install Edlib from it.
-  - if [ $TRAVIS_OS_NAME == "linux" ]; then cd bindings/python && make sdist && cd ../..; fi
-  - if [ $TRAVIS_OS_NAME == "linux" ]; then sudo -H pip install bindings/python/dist/edlib*.tar.gz; fi
-
-script:
-  # Test C/C++ library using CTest.
-  - ninja -C build -v test && cat build/Testing/Temporary/LastTest.log
-  # Check for memory leaks. Returns 2 if there was a memory leak/error, otherwise returns runTests exit code,
-  # which is 0 if all went fine or 1 if some of the tests failed. I test for memory leaks only on linux because
-  # osx returns errors from system libraries, which I would have to supress.
-  # This is run only on smaller number of tests, since executing on valgrind is slow.
-  - if [ $TRAVIS_OS_NAME == "linux" ]; then valgrind --quiet --error-exitcode=2 --tool=memcheck --leak-check=full build/bin/runTests 2; fi
-
-  # Test Python module.
-  - if [ $TRAVIS_OS_NAME == "linux" ]; then sudo -H python bindings/python/test.py; fi
+    #TODO: Add windows x64 and linux aarch64 wheel build

--- a/bindings/python/Makefile
+++ b/bindings/python/Makefile
@@ -1,10 +1,12 @@
 default: build
 
-
-edlib: ../../edlib
-	cp -R ../../edlib .
+.PHONY:
+edlib:
+	# create a clean (maybe updated) copy of edlib src
+	rm -rf edlib && cp -r ../../edlib .
 
 pyedlib.bycython.cpp: edlib.pyx cedlib.pxd
+	python -m pip install cython
 	cython --cplus edlib.pyx -o edlib.bycython.cpp
 
 # To build package, README.rst is needed, because it goes into long description of package,
@@ -19,6 +21,7 @@ buildWithoutREADME.rst: ${BUILD_SOURCE_FILES}
 	EDLIB_OMIT_README_RST=1 python setup.py build_ext -i
 
 README.rst: buildWithoutREADME.rst README-tmpl.rst
+	python -m pip install cogapp
 	cog -d -o README.rst README-tmpl.rst	
 
 BUILD_FILES=${BUILD_SOURCE_FILES} README.rst

--- a/bindings/python/README.md
+++ b/bindings/python/README.md
@@ -5,17 +5,7 @@ This README contains only development information, you can check out full README
 README.rst is not commited to git because it is generated from [README-tmpl.rst](./README-tmpl.rst).
 
 
-## Development
-
-### Setup
-
-Besides python, you will need `cython` and `cog` to build edlib python package.
-
-Run `pip install cython` to install `cython`, which is used to wrap C/C++ code into python.
-
-Run `pip install cogapp` to install `cog`, which is used to generate README.rst from README-tmpl.rst.
-
-### Building
+## Building
 
 Run `make build` to generate an extension module as .so file.
 You can test it then by importing it from python interpreter `import edlib` and running `edlib.align(...)` (you have to be positioned in the directory where .so was built).


### PR DESCRIPTION
A first attempt to get travis to build python wheels with the help of https://github.com/joerick/cibuildwheel.

The previous job scripting has been moved to a yaml anchor to allow the use of two CI stages:
* testing: all of what was happening previously
* pywheels: the building of python wheels.

TODO: the scripting for cibuildwheels needs some work to take account of what goes on in `bindings/python/Makefile` before `python setup.py ...` is called.