### PR TITLE
meson.build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ callgrind.out.*
 core
 
 TAGS
+
+/MESON/
+/PREFIX/

--- a/makefile
+++ b/makefile
@@ -1,0 +1,22 @@
+PREFIX=${CURDIR}/PREFIX
+BDIR=MESON
+TDIR=apps/aligner/test_data
+
+all:
+	${MAKE} setup
+	${MAKE} build
+	${MAKE} integ-test
+build:
+	ninja -v -C ${BDIR}
+test:
+	cd ${BDIR}; meson test -v
+integ-test:
+	${BDIR}/hello-world
+	${BDIR}/edlib-aligner ${TDIR}/query.fasta ${TDIR}/target.fasta
+install:
+	# Install into ${PREFIX}, per setup.
+	ninja -C $B install
+setup:
+	rm -rf ${BDIR}
+	meson setup ${BDIR} . --prefix=${PREFIX}
+.PHONY: all build setup test install

--- a/makefile
+++ b/makefile
@@ -15,7 +15,7 @@ integ-test:
 	${BDIR}/edlib-aligner ${TDIR}/query.fasta ${TDIR}/target.fasta
 install:
 	# Install into ${PREFIX}, per setup.
-	ninja -C $B install
+	ninja -C ${BDIR} install
 setup:
 	rm -rf ${BDIR}
 	meson setup ${BDIR} . --prefix=${PREFIX}

--- a/meson.build
+++ b/meson.build
@@ -16,6 +16,7 @@ edlib_lib = library('edlib',
   dependencies : [],
   install : true,
 )
+install_headers('edlib/include/edlib.h')
 edlib_dep = declare_dependency(
   include_directories : ['edlib/include'],
   link_with : edlib_lib

--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,54 @@
+project(
+  'edlib',
+  'cpp', 'c',
+  version : '1.2.6',
+  default_options : [
+    'buildtype=release',
+    'warning_level=3',
+    'cpp_std=c++11',
+    'b_ndebug=if-release'],
+  license : 'MIT',
+  meson_version : '>= 0.52.0',
+)
+edlib_lib = library('edlib',
+  sources : ['edlib/src/edlib.cpp'],
+  include_directories : ['edlib/include'],
+  dependencies : [],
+  install : true,
+)
+edlib_dep = declare_dependency(
+  include_directories : ['edlib/include'],
+  link_with : edlib_lib
+)
+hello_main = executable(
+  'hello-world',
+  ['apps/hello-world/helloWorld.c'],
+  dependencies : [edlib_dep],
+)
+aligner_main = executable(
+  'edlib-aligner',
+  ['apps/aligner/aligner.cpp'],
+  dependencies : [edlib_dep],
+  install : true,
+)
+runTests_main = executable(
+  'runTests',
+  ['test/runTests.cpp'],
+  dependencies : [edlib_dep],
+  include_directories : ['test'],
+)
+test('runTests', runTests_main,
+)
+test('hello', hello_main,
+)
+test('aligner', aligner_main,
+  args : [
+    files('apps/aligner/test_data/query.fasta',
+          'apps/aligner/test_data/target.fasta'),
+  ],
+)
+
+pkg = import('pkgconfig')
+pkg.generate(edlib_lib,
+  description : 'Lightweight and super fast C/C++ library for sequence alignment using edit distance',
+)


### PR DESCRIPTION
I think **Meson** is way easier to use than **Cmake**, so I've set that up for you. I did not add the performance tests.

    make setup
    make build
    make test  # shows how to be verbose, but "ninja -C MESON test" would work too
    make a  # temporary; useful for debugging
    make install