### PR TITLE
Meson ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,10 @@
 language: cpp
-dist: trusty
+
+dist: xenial
+
+branches:
+  only:
+    - master # This will still build PRs.
 
 stages:
     - ccpp
@@ -11,29 +16,28 @@ env:
         # Encrypted TWINE_PASSWORD:
         - secure: "VfgRi/hcUMLDYzATLS8JOuZo+wg0VNCmEojIJ3gpy89LAXgPN1Qx/2n3c52PPgFWgWFdDgns2SdxhQ1/810qb+65choy2fOgTULnyFcH3ZFTM5nINVHlGB5dLDUesKjrqqfIKHnwB6LAskHqHHPm/qv7WxUjQbcpR6mICsKB7h3NI7yUSc3tRPmd8tVBc/mTUXpMRVznTxGFCo/rC4f2y57GI9odjDxS4VqGS8T9Igvgyteg+ougXYbl84FIi3Bij6TQITa1rP9cFw/lfXMTM2m1czTonzAbgGPC6q7798MCGhLpEdxr+Zu9NPCS8aWFYdxMUYmsisjffDtTdIagZFh/14YrnQb2RxqnLTqSi20E+xXx16GcHhnMOxw/sSOh6HUEaXcbLNtx/mqMEa7mQEcIFBdXHWs/czTHz8xEoGnHIVHI5zqItoK3nUD0W/X6XUex8GP8obvjSKVw2k8X/0bZUaqSyNVbTfYcLmOk53Kx8vfXd82BbTOWiJVZmvuugqrshIEaLOyRhSaoC4Bj5KjfijM/gKPa+n8wVEQ/4hF4HpJKr/33cAm1URDGsDnfvHfxfeEwizTq8gCIxnbpOzSsd1M6+3MQLr48DE8uYM+wkG2F+KsCKe3OexLiaqHG7rVZh1R99nOykoqfjhxek3H1KGfx7qFbdK80AaVBiQo="
 
-
-
 .ccpp: &ccpp
     stage: ccpp
     
     before_install:
+      - sudo -H pip3 install -U pip
+      - sudo -H pip3 install -U setuptools
       - eval "${MATRIX_EVAL}"
     
     install:
-      - if [ $TRAVIS_OS_NAME == "linux" ]; then sudo apt-get install valgrind; fi
+      - sudo -H pip3 install meson ninja # Needed to build C/CPP.
     
     before_script:
-      # Build C/C++ library and apps.
+      # Build C/C++ library and apps using Meson.
+      - CXXFLAGS="-Werror" make
+      # Also check that building with CMake works.
       - mkdir -p build && cd build && CXXFLAGS="-Werror" cmake -GNinja .. && ninja -v && cd ..
     
     script:
-      # Test C/C++ library using CTest.
-      - ninja -C build -v test && cat build/Testing/Temporary/LastTest.log
-      # Check for memory leaks. Returns 2 if there was a memory leak/error, otherwise returns runTests exit code,
-      # which is 0 if all went fine or 1 if some of the tests failed. I test for memory leaks only on linux because
-      # osx returns errors from system libraries, which I would have to supress.
-      # This is run only on smaller number of tests, since executing on valgrind is slow.
-      - if [ $TRAVIS_OS_NAME == "linux" ]; then valgrind --quiet --error-exitcode=2 --tool=memcheck --leak-check=full build/bin/runTests 2; fi
+      - make test
+      # I test for memory leaks only on linux because osx returns errors from
+      # system libraries, which I would have to supress.
+      - if [ $TRAVIS_OS_NAME == "linux" ]; then make check-memory-leaks; fi
 
 .python: &python
     stage: python
@@ -57,6 +61,7 @@ env:
         - if [ $DEPLOY_SDIST_TO_PYPI ]; then make sdist; fi
 
     after_success:
+        # Deploy wheel(s) and source (sdist) to PYPI (if commit is tagged).
         - |
             if [ $TRAVIS_TAG ]; then
                 cd bindings/python
@@ -81,11 +86,11 @@ jobs:
       os: linux
       addons:
         apt:
-          sources:
-            - ubuntu-toolchain-r-test
           packages:
             - g++-4.9
-            - ninja-build
+            - valgrind
+            - python3
+            - python3-pip
       env:
          - MATRIX_EVAL="export CC=gcc-4.9 && export CXX=g++-4.9"
       <<: *ccpp
@@ -95,10 +100,12 @@ jobs:
       addons:
         apt:
           sources:
-            - ubuntu-toolchain-r-test
+            - ubuntu-toolchain-r-test # For g++-9
           packages:
             - g++-9
-            - ninja-build
+            - valgrind
+            - python3
+            - python3-pip
       env:
         - MATRIX_EVAL="export CC=gcc-9 && export CXX=g++-9"
       <<: *ccpp
@@ -107,11 +114,11 @@ jobs:
       os: linux
       addons:
         apt:
-          sources:
-            - llvm-toolchain-trusty-5.0
           packages:
             - clang-5.0
-            - ninja-build
+            - valgrind
+            - python3
+            - python3-pip
       env:
         - MATRIX_EVAL="export CC=clang-5.0 && export CXX=clang++-5.0"
       <<: *ccpp
@@ -119,10 +126,6 @@ jobs:
     - name: "C/CPP (OSX; XCode 11; Clang)"
       os: osx
       osx_image: xcode11
-      addons:
-        homebrew:
-          packages:
-            - ninja
       <<: *ccpp
 
     - name: "Python wheel (Linux)"

--- a/Makefile
+++ b/Makefile
@@ -17,20 +17,27 @@ all:
 
 configure:
 	rm -rf ${BUILD_DIR}
-	meson setup ${BUILD_DIR} .
+	meson setup --backend=ninja ${BUILD_DIR} .
 
 build:
-	ninja -v -C ${BUILD_DIR}
+	meson compile -v -C ${BUILD_DIR}
 
 test:
-	cd ${BUILD_DIR}; meson test -v
+	meson test -v -C ${BUILD_DIR}
 
 integration-tests:
 	${BUILD_DIR}/hello-world
 	${BUILD_DIR}/edlib-aligner ${TEST_DATA_DIR}/query.fasta ${TEST_DATA_DIR}/target.fasta
 
+# Valgrind Returns 2 if there was a memory leak/error,
+# otherwise returns runTests exit code, which is 0 if
+# all went fine or 1 if some of the tests failed.
+check-memory-leaks:
+	valgrind --quiet --error-exitcode=2 --tool=memcheck --leak-check=full \
+      ${BUILD_DIR}/runTests 2
+
 install:
-	cd ${BUILD_DIR}; meson install
+	meson install -C ${BUILD_DIR}
 
 clean:
 	rm -rf ${BUILD_DIR}

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,29 +1,32 @@
 platform:
   - x64
 
-# General idea here is that we have app veyor build worker image (e.g. Visual Studio 2017)
-# on which we run certain commands. Specifically, we use cmake and tell it
-# which Visual Studio version to use to build edlib and then run tests.
+branches:
+  only:
+    - master # This will still build PRs.
+
+image:
+  - Visual Studio 2017
+  - Visual Studio 2019
 
 environment:
   matrix:
-  # Visual Studio 2017
-  - BUILD_TYPE: cmake
-    APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-    VS_VERSION: Visual Studio 15 Win64  # 15 because Visual Studio 2017 is actually version 15.0. Win64 because it is on x64 platform.
+    - arch: x86
+    - arch: x64
 
-  # Visual Studio 2019
-  - BUILD_TYPE: cmake
-    APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
-    VS_VERSION: Visual Studio 16  # 16 because Visual Studio 2019 is actually version 16.0.
-
-shallow_clone: true
+install:
+  - cmd: if %arch%==x86 (set PYTHON_ROOT=C:\python37) else (set PYTHON_ROOT=C:\python37-x64)
+  - cmd: echo Using Python at %PYTHON_ROOT%
+  - cmd: set PATH=%cd%;%PYTHON_ROOT%;%PYTHON_ROOT%\Scripts;%PATH%
+  - cmd: pip install ninja meson
+  # Enable using MSVC through command line.
+  - cmd: if "%APPVEYOR_BUILD_WORKER_IMAGE%"=="Visual Studio 2017" ( call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvarsall.bat" %arch% )
+  - cmd: if "%APPVEYOR_BUILD_WORKER_IMAGE%"=="Visual Studio 2019" ( call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvarsall.bat" %arch% )
 
 build_script:
-  - cmake -G "%VS_VERSION%" .
-  - cmake --build . --config Release
+  - cmd: echo Building on image %APPVEYOR_BUILD_WORKER_IMAGE%, arch %arch%.
+  - cmd: meson setup --backend=ninja build_dir .
+  - cmd: meson compile -v -C build_dir
 
 test_script:
-  - bin\Release\runTests.exe
-
-deploy: off
+  - cmd: meson test -C build_dir

--- a/edlib/include/edlib.h
+++ b/edlib/include/edlib.h
@@ -7,6 +7,27 @@
  * @brief Main header file, containing all public functions and structures.
  */
 
+// Define EDLIB_API macro that, when on Windows and building a DLL,
+// exports a function/struct so it is visible in the generated DLL.
+// While this happens by default on Unix, it does not
+// on Windows, and DLL will not be successfully linked, so we have to
+// explicitely put this macro in front of every function/struct in here
+// that is part of the Edlib API.
+// EDLIB_DLL_EXPORT should be defined in the .cpp that implements this header.
+// Check discussion here for more details:
+//   https://github.com/Martinsos/edlib/pull/165
+// or check this SO answer:
+//   https://stackoverflow.com/a/538179/1509394
+#if defined(_WIN32) || defined(_WIN64) || defined(__MINGW32__)
+#    ifdef EDLIB_DLL_EXPORT
+#        define EDLIB_API __declspec(dllexport)
+#    else
+#        define EDLIB_API __declspec(dllimport)
+#    endif
+#else
+#    define EDLIB_API
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -18,7 +39,7 @@ extern "C" {
     /**
      * Alignment methods - how should Edlib treat gaps before and after query?
      */
-    typedef enum {
+    EDLIB_API typedef enum {
         /**
          * Global method. This is the standard method.
          * Useful when you want to find out how similar is first sequence to second sequence.
@@ -49,7 +70,7 @@ extern "C" {
     /**
      * Alignment tasks - what do you want Edlib to do?
      */
-    typedef enum {
+    EDLIB_API typedef enum {
         EDLIB_TASK_DISTANCE,  //!< Find edit distance and end locations.
         EDLIB_TASK_LOC,       //!< Find edit distance, end locations and start locations.
         EDLIB_TASK_PATH       //!< Find edit distance, end locations and start locations and alignment path.
@@ -60,7 +81,7 @@ extern "C" {
      * @see http://samtools.github.io/hts-specs/SAMv1.pdf
      * @see http://drive5.com/usearch/manual/cigar.html
      */
-    typedef enum {
+    EDLIB_API typedef enum {
         EDLIB_CIGAR_STANDARD,  //!< Match: 'M', Insertion: 'I', Deletion: 'D', Mismatch: 'M'.
         EDLIB_CIGAR_EXTENDED   //!< Match: '=', Insertion: 'I', Deletion: 'D', Mismatch: 'X'.
     } EdlibCigarFormat;
@@ -74,7 +95,7 @@ extern "C" {
     /**
      * @brief Defines two given characters as equal.
      */
-    typedef struct {
+    EDLIB_API typedef struct {
         char first;
         char second;
     } EdlibEqualityPair;
@@ -82,7 +103,7 @@ extern "C" {
     /**
      * @brief Configuration object for edlibAlign() function.
      */
-    typedef struct {
+    EDLIB_API typedef struct {
         /**
          * Set k to non-negative value to tell edlib that edit distance is not larger than k.
          * Smaller k can significantly improve speed of computation.
@@ -128,21 +149,23 @@ extern "C" {
      * Helper method for easy construction of configuration object.
      * @return Configuration object filled with given parameters.
      */
-    EdlibAlignConfig edlibNewAlignConfig(int k, EdlibAlignMode mode, EdlibAlignTask task,
-                                         const EdlibEqualityPair* additionalEqualities,
-                                         int additionalEqualitiesLength);
+    EDLIB_API EdlibAlignConfig edlibNewAlignConfig(
+        int k, EdlibAlignMode mode, EdlibAlignTask task,
+        const EdlibEqualityPair* additionalEqualities,
+        int additionalEqualitiesLength
+    );
 
     /**
      * @return Default configuration object, with following defaults:
      *         k = -1, mode = EDLIB_MODE_NW, task = EDLIB_TASK_DISTANCE, no additional equalities.
      */
-    EdlibAlignConfig edlibDefaultAlignConfig(void);
+    EDLIB_API EdlibAlignConfig edlibDefaultAlignConfig(void);
 
 
     /**
      * Container for results of alignment done by edlibAlign() function.
      */
-    typedef struct {
+    EDLIB_API typedef struct {
         /**
          * EDLIB_STATUS_OK or EDLIB_STATUS_ERROR. If error, all other fields will have undefined values.
          */
@@ -204,7 +227,7 @@ extern "C" {
      * Frees memory in EdlibAlignResult that was allocated by edlib.
      * If you do not use it, make sure to free needed members manually using free().
      */
-    void edlibFreeAlignResult(EdlibAlignResult result);
+    EDLIB_API void edlibFreeAlignResult(EdlibAlignResult result);
 
 
     /**
@@ -222,9 +245,11 @@ extern "C" {
      * @return  Result of alignment, which can contain edit distance, start and end locations and alignment path.
      *          Make sure to clean up the object using edlibFreeAlignResult() or by manually freeing needed members.
      */
-    EdlibAlignResult edlibAlign(const char* query, int queryLength,
-                                const char* target, int targetLength,
-                                const EdlibAlignConfig config);
+    EDLIB_API EdlibAlignResult edlibAlign(
+        const char* query, int queryLength,
+        const char* target, int targetLength,
+        const EdlibAlignConfig config
+    );
 
 
     /**
@@ -246,10 +271,10 @@ extern "C" {
      *     Needed memory is allocated and given pointer is set to it.
      *     Do not forget to free it later using free()!
      */
-    char* edlibAlignmentToCigar(const unsigned char* alignment, int alignmentLength,
-                                EdlibCigarFormat cigarFormat);
-
-
+    EDLIB_API char* edlibAlignmentToCigar(
+        const unsigned char* alignment, int alignmentLength,
+        EdlibCigarFormat cigarFormat
+    );
 
 #ifdef __cplusplus
 }

--- a/edlib/src/edlib.cpp
+++ b/edlib/src/edlib.cpp
@@ -1,3 +1,4 @@
+#define EDLIB_DLL_EXPORT
 #include "edlib.h"
 
 #include <stdint.h>

--- a/meson.build
+++ b/meson.build
@@ -7,7 +7,7 @@ project(
     'warning_level=3',
     'cpp_std=c++14',
     'b_ndebug=if-release',
-    'default_library=both'
+    'default_library=both',
   ],
   license : 'MIT',
   meson_version : '>= 0.52.0',
@@ -23,7 +23,7 @@ edlib_lib = library('edlib',
 install_headers('edlib/include/edlib.h')
 
 edlib_dep = declare_dependency(
-  include_directories : ['edlib/include'],
+  include_directories : include_directories('edlib/include'),
   link_with : edlib_lib
 )
 
@@ -33,30 +33,34 @@ hello_main = executable(
   dependencies : [edlib_dep],
 )
 
-aligner_main = executable(
-  'edlib-aligner',
-  files(['apps/aligner/aligner.cpp']),
-  dependencies : [edlib_dep],
-  install : true,
-)
+if build_machine.system() != 'windows'
+  aligner_main = executable(
+    'edlib-aligner',
+    files(['apps/aligner/aligner.cpp']),
+    dependencies : [edlib_dep],
+    install : true,
+  )
+endif
 
 runTests_main = executable(
   'runTests',
   files(['test/runTests.cpp']),
   dependencies : [edlib_dep],
-  include_directories : ['test'],
+  include_directories : include_directories('test'),
 )
 
 test('runTests', runTests_main)
 
 test('hello', hello_main)
 
-test('aligner', aligner_main,
-  args : [
-    files('apps/aligner/test_data/query.fasta',
-          'apps/aligner/test_data/target.fasta'),
-  ],
-)
+if build_machine.system() != 'windows'
+  test('aligner', aligner_main,
+    args : [
+      files('apps/aligner/test_data/query.fasta',
+            'apps/aligner/test_data/target.fasta'),
+    ],
+  )
+endif
 
 pkg = import('pkgconfig')
 pkg.generate(edlib_lib,


### PR DESCRIPTION
@cdunn2001 and @SoapZA , it would be great if you could lend me a little bit of help with getting this PR integrated!
I pushed as far as I could on my own and would love to get your comments on what could be done better + how to fix some things.

What is not working at the moment:
1. I can't get meson working on appveyor, windows. I followed their suggestion from https://mesonbuild.com/Continuous-Integration.html#appveyor-for-windows, but I am getting error 
```
Found ninja-1.10.0.git.kitware.jobserver-1 at C:\python37-x64\Scripts\ninja.EXE
meson compile -C build_dir
ninja: Entering directory `build_dir'
[1/8] Compiling C object hello-world.exe.p/apps_hello-world_helloWorld.c.obj
[2/8] Compiling C++ object runTests.exe.p/test_runTests.cpp.obj
[3/8] Compiling C++ object edlib.dll.p/edlib_src_edlib.cpp.obj
[4/8] Linking static target libedlib.a
[5/8] Linking target edlib.dll
[6/8] Generating symbol file edlib.dll.p/edlib.dll.symbols
[7/8] Linking target hello-world.exe
FAILED: hello-world.exe 
"link"  /MACHINE:x64 /OUT:hello-world.exe hello-world.exe.p/apps_hello-world_helloWorld.c.obj "/nologo" "/release" "/nologo" "/OPT:REF" "edlib.lib" "/SUBSYSTEM:CONSOLE" "kernel32.lib" "user32.lib" "gdi32.lib" "winspool.lib" "shell32.lib" "ole32.lib" "oleaut32.lib" "uuid.lib" "comdlg32.lib" "advapi32.lib"
LINK : fatal error LNK1181: cannot open input file 'edlib.lib'
[8/8] Linking target runTests.exe
FAILED: runTests.exe 
```
I found this QA in their FAQ: https://mesonbuild.com/FAQ.html .
Solution seems to be adding certain statements in the C/C++ code, but I don't feel like I will be able to do this properly, with understanding, unless I invest some decent time into understanding the whole context of it, which I can't do at the moment due to other obligations. Btw. notice that I added option in meson.build to build both static and shared library -> I am not sure how that influences the whole thing. Also, I wonder how is it that this worked out of the box in Cmake but does not in Meson. I read somewhere it is because CMake uses some kind of opinionated solution for this and Meson authors did not want to make such opinionated approach. Anyway, if you could help me figure this out, that would be tremendous help!

2. ~~Since I installed python3 for meson, I can't get edlib python binding to compile -> there seems to be some mismatch between python2 and python3, as if a part of binding is using python3 but expecting python2. I can solve this in some later PR, this is not urgent, but if you have some immediate idea on what is the problem, I am all ears. Why haven't I personally solved it yet? I don't really use python much normally, so my knowledge of the whole versioning and packaging is lacking. Don't bother with this if it is not your thing, I just thought I would mention it, in case you have some ideas. The thing with Appveyor is more pressing.~~ -> This actually just got solved with another PR I just merged, that introduced building of python wheels and since it split travis build into stages, it also took care of conflicting python versions.
