### PR TITLE
Fix potential ODR violation due to weak symbols being overridden

### DIFF
--- a/edlib/src/edlib.cpp
+++ b/edlib/src/edlib.cpp
@@ -7,6 +7,8 @@
 #include <cstring>
 #include <string>
 
+namespace {
+
 using namespace std;
 
 typedef uint64_t Word;
@@ -89,6 +91,8 @@ public:
         return matrix[a][b];
     }
 };
+
+} // anonymous namespace
 
 static int myersCalcEditDistanceSemiGlobal(const Word* Peq, int W, int maxNumBlocks,
                                            int queryLength,


### PR DESCRIPTION
Reproducer:
```c++
// g++ repro.cpp edlib.cpp -o repro

#include "edlib.h"
#include <cstdio>

struct Block {
  Block();
};

// Shouldn't be called because no instance of `Block` is created in this file.
Block::Block() { printf("This shouldn't be called\n"); }

int main() {
  EdlibAlignConfig config{};
  config.mode = EDLIB_MODE_SHW;
  EdlibAlignResult result = edlibAlign("a", 1, "b", 1, config);
  edlibFreeAlignResult(result);
}
```

```
# Note that the same result is observed when using clang++ too.
$ g++ repro.cpp edlib.cpp -o repro
$ ./repro
This shouldn't be called
```

The issue is that `Block`'s constructor is exported as a weak symbol from whichever translation unit has the contents of `edlib.cpp` since it defaults to external linkage. To fix this we wrap the types in an anonymous namespace to give them internal linkage and hide them from any client code.