### PR TITLE
Bump minimum CMake version to 3.5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.20 FATAL_ERROR)
 project(edlib VERSION 1.2.6)
 
 option(EDLIB_ENABLE_INSTALL "Generate the install target" ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.2 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
 project(edlib VERSION 1.2.6)
 
 option(EDLIB_ENABLE_INSTALL "Generate the install target" ON)


### PR DESCRIPTION
With the recent release of CMake 4.0, support for versions less than 3.5 have been removed.

This is a minimal bump to get things building again, though note that CMake now warns about a future deprecation:
```
[cmake] CMake Deprecation Warning at edlib/CMakeLists.txt:1 (cmake_minimum_required):
[cmake]   Compatibility with CMake < 3.10 will be removed from a future version of
[cmake]   CMake.
```