### PR TITLE
windows ci

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,14 +1,14 @@
 name: CI
 
-on:
-  push:
-    branches:
-      - master
-    tags:
-      - '*'
-  pull_request:
-    branches:
-      - master
+# on:
+#   push:
+#     branches:
+#       - master
+#     tags:
+#       - '*'
+#   pull_request:
+#     branches:
+#       - master
 
 jobs:
   cpp_edlib:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,14 +1,14 @@
 name: CI
 
-# on:
-#   push:
-#     branches:
-#       - master
-#     tags:
-#       - '*'
-#   pull_request:
-#     branches:
-#       - master
+on:
+  push:
+    branches:
+      - master
+    tags:
+      - '*'
+  pull_request:
+    branches:
+      - master
 
 jobs:
   cpp_edlib:

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -1,5 +1,3 @@
-name: CI
-
 on:
   push:
     branches:

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -29,7 +29,7 @@ jobs:
           msbuild-architecture: ${{ matrix.arch }}
       - name: Build
         run: |
-          cmake -A ${{ matrix.arch == "x86" && "x86" || "Win32" }} .
+          cmake -A ${{ matrix.arch == 'x86' && 'x86' || 'Win32' }} .
           cmake --build . --config Release
       - name: Test
         run: |

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -65,7 +65,7 @@ jobs:
       matrix:
         python:
           - "3.12"
-          - "3.10"
+          - "3.11"
     runs-on: windows-2022
     steps:
       - uses: actions/checkout@v4
@@ -76,11 +76,12 @@ jobs:
         with:
           python-version: "${{ matrix.python }} "
       - name: install dependencies
-        run: python -m pip install cython build cibuildwheel
+        run: python -m pip install cython build cibuildwheel cogapp
       - name: Build
         run: |
           cd bindings/python
           robocopy ..\..\edlib . /E
           cython --cplus edlib.pyx -o edlib.bycython.cpp
+          cog -d -o README.rst README-tmpl.rst
           python -m build --sdist
           python -m cibuildwheel --output-dir wheelhouse

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -82,7 +82,7 @@ jobs:
           EDLIB_OMIT_README_RST: 1-
         run: |
           cd bindings/python
-          robocopy ..\..\edlib . /E
+          robocopy ..\..\edlib edlib /E
           python -m pip install -e .
           cython --cplus edlib.pyx -o edlib.bycython.cpp
           cog -d -o README.rst README-tmpl.rst

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -32,5 +32,6 @@ jobs:
           cmake .
           cmake --build . --config Release
       - name: Test
+        run: |
           file bin\Release\runTests.exe
           bin\Release\runTests.exe

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -29,7 +29,7 @@ jobs:
           msbuild-architecture: ${{ matrix.arch }}
       - name: Build
         run: |
-          cmake -A ${{ matrix.arch == 'x86' && 'x86' || 'Win32' }} .
+          cmake -A ${{ matrix.arch == 'x86' && 'Win32' || matrix.arch }} .
           cmake --build . --config Release
       - name: Test
         run: |

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -65,6 +65,9 @@ jobs:
       - uses: microsoft/setup-msbuild@v2
         with:
           vs-version: 17
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
       - name: install dependencies
         run: python -m pip install cython build cibuildwheel cogapp
       - name: Build

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -61,25 +61,18 @@ jobs:
 
   python:
     name: "python bindings"
-    strategy:
-      matrix:
-        python:
-          - "3.12"
-          - "3.11"
     runs-on: windows-2022
     steps:
       - uses: actions/checkout@v4
       - uses: microsoft/setup-msbuild@v2
         with:
           vs-version: 17
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "${{ matrix.python }} "
       - name: install dependencies
         run: python -m pip install cython build cibuildwheel cogapp
       - name: Build
         env:
-          EDLIB_OMIT_README_RST: 1-
+          EDLIB_OMIT_README_RST: 1
+          CIBW_TEST_COMMAND: "python3 {project}/test.py"
         run: |
           cd bindings/python
           robocopy ..\..\edlib edlib /E

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -29,7 +29,7 @@ jobs:
           msbuild-architecture: ${{ matrix.arch }}
       - name: Build
         run: |
-          cmake -A ${{ matrix.arch == x86 && x86 || Win32 }} .
+          cmake -A ${{ matrix.arch == "x86" && "x86" || "Win32" }} .
           cmake --build . --config Release
       - name: Test
         run: |

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -64,8 +64,8 @@ jobs:
     strategy:
       matrix:
         python:
-          - 3.12
-          - 3.10
+          - "3.12"
+          - "3.10"
     runs-on: windows-2022
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -77,10 +77,14 @@ jobs:
           python-version: "${{ matrix.python }} "
       - name: install dependencies
         run: python -m pip install cython build cibuildwheel cogapp
-      - name: Build
-        run: |
+      - run: |
           cd bindings/python
           robocopy ..\..\edlib . /E
+      - name: Build w/o rts
+        env: EDLIB_OMIT_README_RST=1
+        run: python -m pip install -e .
+      - name: Build
+        run: |
           cython --cplus edlib.pyx -o edlib.bycython.cpp
           cog -d -o README.rst README-tmpl.rst
           python -m build --sdist

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -11,8 +11,8 @@ on:
       - master
 
 jobs:
-  cpp_edlib:
-    name: "Check that CPP edlib correctly builds and passes tests."
+  cmake_build:
+    name: "CMake build"
     strategy:
       matrix:
         arch:
@@ -20,10 +20,8 @@ jobs:
           - x86
     runs-on: windows-2022
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-      - name: Set C/CPP compiler to use
-        uses: microsoft/setup-msbuild@v2
+      - uses: actions/checkout@v4
+      - uses: microsoft/setup-msbuild@v2
         with:
           vs-version: 17
           msbuild-architecture: ${{ matrix.arch }}
@@ -33,5 +31,27 @@ jobs:
           cmake --build . --config Release
       - name: Test
         run: |
-          file bin\Release\runTests.exe
           bin\Release\runTests.exe
+
+  mason_build:
+    name: "mason build"
+    strategy:
+      matrix:
+        linking:
+          - static
+          - shared
+    runs-on: windows-2022
+    steps:
+      - uses: actions/checkout@v4
+      - uses: microsoft/setup-msbuild@v2
+        with:
+          vs-version: 17
+      - name: Build
+        run: |
+          SPECIFIER=meson-build-${{ matrix.linking }}
+          meson setup --backend=ninja -Ddefault_library=${{ matrix.linking }} $SPECIFIER .
+          meson compile -v -C $SPECIFIER
+      - name: Test
+        run: |
+          SPECIFIER=meson-build-${{ matrix.linking }}
+          meson test -C $SPECIFIER

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -29,7 +29,7 @@ jobs:
           msbuild-architecture: ${{ matrix.arch }}
       - name: Build
         run: |
-          cmake .
+          cmake -A ${{ matrix.arch == x86 && x86 || Win32 }} .
           cmake --build . --config Release
       - name: Test
         run: |

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -22,18 +22,15 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.x"
-
-      - name: Install Python packages
-        run: |
-          python -m pip install --upgrade pip setuptools meson ninja
-
       - name: Set C/CPP compiler to use
-        shell: cmd
+        uses: microsoft/setup-msbuild@v2
+        with:
+          vs-version: 17
+          msbuild-architecture: ${{ matrix.arch }}
+      - name: Build
         run: |
-          "C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Auxiliary\Build\vcvars64.bat" ${{ matrix.arch }}
           cmake .
           cmake --build . --config Release
+      - name: Test
+          file bin\Release\runTests.exe
+          bin\Release\runTests.exe

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -77,15 +77,13 @@ jobs:
           python-version: "${{ matrix.python }} "
       - name: install dependencies
         run: python -m pip install cython build cibuildwheel cogapp
-      - run: |
+      - name: Build
+        env:
+          EDLIB_OMIT_README_RST: 1-
+        run: |
           cd bindings/python
           robocopy ..\..\edlib . /E
-      - name: Build w/o rts
-        env:
-          EDLIB_OMIT_README_RST: 1
-        run: python -m pip install -e .
-      - name: Build
-        run: |
+          python -m pip install -e .
           cython --cplus edlib.pyx -o edlib.bycython.cpp
           cog -d -o README.rst README-tmpl.rst
           python -m build --sdist

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -58,3 +58,29 @@ jobs:
       - name: Test
         run: |
           meson test -C meson-build-${{ matrix.linking }}
+
+  python:
+    name: "python bindings"
+    strategy:
+      matrix:
+        python:
+          - 3.12
+          - 3.10
+    runs-on: windows-2022
+    steps:
+      - uses: actions/checkout@v4
+      - uses: microsoft/setup-msbuild@v2
+        with:
+          vs-version: 17
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "${{ matrix.python }} "
+      - name: install dependencies
+        run: python -m pip install cython build cibuildwheel
+      - name: Build
+        run: |
+          cd bindings/python
+          robocopy ..\..\edlib . /E
+          cython --cplus edlib.pyx -o edlib.bycython.cpp
+          python -m build --sdist
+          python -m cibuildwheel --output-dir wheelhouse

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -1,0 +1,39 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - master
+    tags:
+      - "*"
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  cpp_edlib:
+    name: "Check that CPP edlib correctly builds and passes tests."
+    strategy:
+      matrix:
+        arch:
+          - x64
+          - x86
+    runs-on: windows-2022
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
+      - name: Install Python packages
+        run: |
+          python -m pip install --upgrade pip setuptools meson ninja
+
+      - name: Set C/CPP compiler to use
+        shell: cmd
+        run: |
+          "C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Auxiliary\Build\vcvars64.bat" ${{ matrix.arch }}
+          cmake .
+          cmake --build . --config Release

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -34,7 +34,7 @@ jobs:
           bin\Release\runTests.exe
 
   mason_build:
-    name: "mason build"
+    name: "meson build"
     strategy:
       matrix:
         linking:
@@ -50,7 +50,7 @@ jobs:
         with:
           python-version: "3.x"
       - name: install dependencies
-        run: python -m pip install ninja mason
+        run: python -m pip install ninja meson
       - name: Build
         run: |
           meson setup --backend=ninja -Ddefault_library=${{ matrix.linking }} meson-build-${{ matrix.linking }} .

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -73,7 +73,7 @@ jobs:
       - name: Build
         env:
           EDLIB_OMIT_README_RST: 1
-          CIBW_TEST_COMMAND: "python3 {project}/test.py"
+          CIBW_TEST_COMMAND: "python {project}/test.py"
         run: |
           cd bindings/python
           robocopy ..\..\edlib edlib /E

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -46,12 +46,15 @@ jobs:
       - uses: microsoft/setup-msbuild@v2
         with:
           vs-version: 17
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+      - name: install dependencies
+        run: python -m pip install ninja mason
       - name: Build
         run: |
-          SPECIFIER=meson-build-${{ matrix.linking }}
-          meson setup --backend=ninja -Ddefault_library=${{ matrix.linking }} $SPECIFIER .
-          meson compile -v -C $SPECIFIER
+          meson setup --backend=ninja -Ddefault_library=${{ matrix.linking }} meson-build-${{ matrix.linking }} .
+          meson compile -v -C meson-build-${{ matrix.linking }}
       - name: Test
         run: |
-          SPECIFIER=meson-build-${{ matrix.linking }}
-          meson test -C $SPECIFIER
+          meson test -C meson-build-${{ matrix.linking }}

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -81,7 +81,8 @@ jobs:
           cd bindings/python
           robocopy ..\..\edlib . /E
       - name: Build w/o rts
-        env: EDLIB_OMIT_README_RST=1
+        env:
+          EDLIB_OMIT_README_RST: 1
         run: python -m pip install -e .
       - name: Build
         run: |


### PR DESCRIPTION
fixes: #239

Made a separate action yaml for windows including:
 * CMake
 * meson
 * cibuildwheel

Some warnings that I encountered:
 * `cl : Command line warning D9002 : ignoring unknown option '-O3'` caused by [OS specific flags](https://github.com/Martinsos/edlib/blob/master/bindings/python/setup.py#L46)
 * `edlib\src\edlib.cpp(374,83): warning C4244: 'argument': conversion from 'int' to 'unsigned char', possible loss of data`

Aside from these, every test passes 🤗 